### PR TITLE
Mana Blast fixed

### DIFF
--- a/src/main/java/am2/spell/component/ManaBlast.java
+++ b/src/main/java/am2/spell/component/ManaBlast.java
@@ -69,9 +69,9 @@ public class ManaBlast extends SpellComponent{
 
 	@Override
 	public void spawnParticles(World world, double x, double y, double z, EntityLivingBase caster, Entity target, Random rand, int colorModifier){
-		int snapAngle = 360 / ArsMagica2.config.getGFXLevel() * 5;
+		double snapAngle = (2 * Math.PI) / (ArsMagica2.config.getGFXLevel() + 1)* 5;
 		for (int j = 0; j < 4; j++) {
-			for (int i = 0; i < ArsMagica2.config.getGFXLevel() * 5; i++) {
+			for (int i = 0; i < (ArsMagica2.config.getGFXLevel() + 1) * 5; i++) {
 				double posX = x + (Math.cos(snapAngle * i) * (j * 0.5));
 				double posZ = z + (Math.sin(snapAngle * i) * (j * 0.5));
 				AMParticle particle = (AMParticle) ArsMagica2.proxy.particleManager.spawn(world, "sparkle2", posX, target.posY + target.height / 2 + j * 0.5, posZ);


### PR DESCRIPTION
No longer dividing by 0, and using 2pi radians base instead of ~ 1.85
radians. Solves #249, unless there are other components with this issue than the one noted.