### PR TITLE
Fix issues with Item#getHarvestLevel() and the Dig component

### DIFF
--- a/src/main/java/am2/items/SpellBase.java
+++ b/src/main/java/am2/items/SpellBase.java
@@ -175,12 +175,13 @@ public class SpellBase extends ItemSpellBase{
 	}
 
 	@Override
-	public boolean onBlockStartBreak(ItemStack p_onBlockStartBreak_1_, BlockPos p_onBlockStartBreak_2_, EntityPlayer p_onBlockStartBreak_3_) {
-		return false;
+	public boolean onBlockStartBreak(ItemStack stack, BlockPos pos, EntityPlayer player) {
+	    player.worldObj.destroyBlock(pos, player.canHarvestBlock(player.worldObj.getBlockState(pos)));
+	    return true;
 	}
 
 	@Override
 	public int getHarvestLevel(ItemStack stack, String toolClass, @Nullable EntityPlayer player, @Nullable IBlockState blockState) {
-		return stack.getTagCompound().hasKey("ArsMagica2.harvestByProjectile") && stack.getTagCompound().getBoolean("ArsMagica2.harvestByProjectile") == true ? SpellUtils.getModifiedInt_Add(2, stack, (EntityLivingBase)player, (EntityLivingBase)player, player.getEntityWorld(), SpellModifiers.MINING_POWER) : -1;
+	    return SpellUtils.getModifiedInt_Add(2, stack, (EntityLivingBase)player, (EntityLivingBase)player, player.getEntityWorld(), SpellModifiers.MINING_POWER);
 	}
 }

--- a/src/main/java/am2/spell/component/Dig.java
+++ b/src/main/java/am2/spell/component/Dig.java
@@ -47,7 +47,6 @@ public class Dig extends SpellComponent {
 	public boolean applyEffectBlock(ItemStack stack, World world, BlockPos blockPos, EnumFacing blockFace, double impactX, double impactY, double impactZ, EntityLivingBase caster) {
 		if (!(caster instanceof EntityPlayer))
 			return false;
-		stack.getTagCompound().setBoolean("ArsMagica2.harvestByProjectile", true);
 		if (world.isRemote)
 			return true;
         if (SpellUtils.modifierIsPresent(SpellModifiers.SILKTOUCH_LEVEL, stack)) {


### PR DESCRIPTION
Github is drunk today, so the diff is really weird. I tried to fix it, but Github still insisted that I changed the entire file. Anyway, this PR makes SpellBase#getHarvestLevel() more reliable, the old impl had weird issues, which neither I nor Growlith could figure out. 

I have checked and this PR does not allow spell items to be used as pickaxes/shovels/axes.