### PR TITLE
Rewriting magic resist

### DIFF
--- a/src/main/java/am2/enchantments/EnchantMagicResist.java
+++ b/src/main/java/am2/enchantments/EnchantMagicResist.java
@@ -3,9 +3,12 @@ package am2.enchantments;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.enchantment.EnumEnchantmentType;
+import net.minecraft.entity.EntityCreature;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.passive.EntityCow;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.EntityEquipmentSlot;
-import net.minecraft.util.math.MathHelper;
+import net.minecraft.item.ItemStack;
 
 public class EnchantMagicResist extends Enchantment{
 
@@ -19,14 +22,28 @@ public class EnchantMagicResist extends Enchantment{
 		return 5;
 	}
 
-	public static int ApplyEnchantment(EntityLivingBase inventory, int damage){
-		int maxEnchantLevel = EnchantmentHelper.getMaxEnchantmentLevel(AMEnchantments.magicResist, inventory);
-
-		if (maxEnchantLevel > 0){
-			damage -= MathHelper.floor_float((float)damage * (float)maxEnchantLevel * 0.15F);
+	public static float ApplyEnchantment(EntityLivingBase entity, float damage){
+		ItemStack[] armorList = null;
+		float newDamage = damage;
+		int totalMRLevel = 0;
+		if (!(entity instanceof EntityPlayer)) {
+			return damage;
+		}else{
+			armorList = ((EntityPlayer)entity).inventory.armorInventory;
 		}
-
-		return damage;
+		if (armorList.length > 0){
+			for (ItemStack armor : armorList){
+				totalMRLevel += EnchantmentHelper.getEnchantmentLevel(AMEnchantments.magicResist, armor);
+			}
+		}
+		
+		if (totalMRLevel > 0){
+			//ewDamage -= damage * totalMRLevel * 0.05f;
+			//log scale, it is kind of ridiculous, as 1/4 of the resources reaps more than half the max benefit
+			newDamage = (float) (damage - damage * 0.32845873875f * Math.log1p(totalMRLevel));
+		}
+		
+		return newDamage;
 	}
 
 }

--- a/src/main/java/am2/handler/EntityHandler.java
+++ b/src/main/java/am2/handler/EntityHandler.java
@@ -24,6 +24,7 @@ import am2.api.skill.SkillPoint;
 import am2.armor.ArmorHelper;
 import am2.armor.infusions.GenericImbuement;
 import am2.defs.ItemDefs;
+import am2.enchantments.EnchantMagicResist;
 import am2.extensions.AffinityData;
 import am2.extensions.EntityExtension;
 import am2.extensions.RiftStorage;
@@ -57,6 +58,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
@@ -73,6 +75,7 @@ import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.living.LivingDropsEvent;
+import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingJumpEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
@@ -235,7 +238,7 @@ public class EntityHandler {
                 double newVel = Math.sqrt(projectile.motionX * projectile.motionX + projectile.motionY * projectile.motionY + projectile.motionZ * projectile.motionZ);
 
                 projectile.motionX = newVel * rX;
-                //projectile.motionY = newVel * rY;
+                projectile.motionY = newVel * rY;
                 projectile.motionZ = newVel * rZ;
             }
 		}
@@ -520,4 +523,14 @@ public class EntityHandler {
 			EntityItemWatcher.instance.addWatchedItem((EntityItem) event.getEntity());
 		}
 	}
+	
+//	@SubscribeEvent(priority = EventPriority.LOWEST)
+//    public void entityDamageEvent(LivingHurtEvent event) {
+//		EntityLivingBase entity = (EntityLivingBase) event.getEntity();
+//		if (event.getSource() == DamageSource.magic || event.getSource() == DamageSource.dragonBreath){
+//			float newDamage = EnchantMagicResist.ApplyEnchantment(entity, event.getAmount());
+//	        event.setAmount(newDamage);
+//		}
+//    }
+	
 }

--- a/src/main/java/am2/handler/PotionEffectHandler.java
+++ b/src/main/java/am2/handler/PotionEffectHandler.java
@@ -13,6 +13,7 @@ import am2.buffs.BuffEffectTemporalAnchor;
 import am2.buffs.BuffStatModifiers;
 import am2.defs.ItemDefs;
 import am2.defs.PotionEffectsDefs;
+import am2.enchantments.EnchantMagicResist;
 import am2.extensions.EntityExtension;
 import am2.utils.DimensionUtilities;
 import am2.utils.KeystoneUtilities;
@@ -20,6 +21,7 @@ import am2.utils.SelectionUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.model.ItemCameraTransforms.TransformType;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityBoat;
 import net.minecraft.entity.item.EntityMinecart;
 import net.minecraft.item.ItemStack;
@@ -79,6 +81,13 @@ public class PotionEffectHandler {
 			event.setAmount(event.getAmount() * 0.25f);
 		
 		float damage = EntityExtension.For(event.getEntityLiving()).protect(event.getAmount());
+		
+		EntityLivingBase entity = (EntityLivingBase) event.getEntity();
+		
+		if (event.getSource().damageType.equals(DamageSource.magic.damageType) || event.getSource().damageType.equals(DamageSource.dragonBreath.damageType)){
+			damage = EnchantMagicResist.ApplyEnchantment(entity, damage);
+		}
+		
 		event.setAmount(damage);
 	}	
 	

--- a/src/main/java/am2/spell/component/MagicDamage.java
+++ b/src/main/java/am2/spell/component/MagicDamage.java
@@ -4,7 +4,6 @@ import java.util.EnumSet;
 import java.util.Random;
 import java.util.Set;
 
-import am2.enchantments.AMEnchantments;
 import com.google.common.collect.Sets;
 
 import am2.ArsMagica2;
@@ -15,10 +14,8 @@ import am2.api.spell.SpellModifiers;
 import am2.defs.ItemDefs;
 import am2.particles.AMParticle;
 import am2.utils.SpellUtils;
-import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.ItemStack;
@@ -39,16 +36,6 @@ public class MagicDamage extends SpellComponent{
 		if (!(target instanceof EntityLivingBase)) return false;
 		float baseDamage = 6;
 		double damage = SpellUtils.getModifiedDouble_Add(baseDamage, stack, caster, target, world, SpellModifiers.DAMAGE);
-		float mod = 0.0f;
-		if (target instanceof EntityPlayer){
-			for (ItemStack item : ((EntityPlayer)target).inventory.armorInventory){
-				if (item == null)
-					continue;
-				if (EnchantmentHelper.getEnchantmentLevel(AMEnchantments.magicResist, item) > 0)
-					mod = mod + (0.04f * EnchantmentHelper.getEnchantmentLevel(AMEnchantments.magicResist, item));
-			}
-		}
-		damage = damage - (damage * mod);
 		return SpellUtils.attackTargetSpecial(stack, target, DamageSources.causeMagicDamage(caster), SpellUtils.modifyDamage(caster, (float)damage));
 	}
 


### PR DESCRIPTION
I don't know who came up with the idea to just tweak magic damage the component (mana blast, arcane guardian, and other magic damage sources would completely bypass magic resist). For now I would just leave the code in potionhandler to not have another listener running, and have it work smoothly with things like mana shield and magic shield. Oh yea, it also works on a pretty ridiculous log scale.

Current formula: 
y = e^(x/0.32845873875) - 1

where x is the total level of magic resist of all equipped armor, and y is the percent reduction granted.

Example: at 20 total levels (full MR 5 armor set), y would be 1, or 100% damage reduction. 
Here's a table with a few level values:

Total Magic Resist Level | Percent Reduction Granted
-----------1---------------------------22.8%
-----------3---------------------------45.6%
-----------4---------------------------53.9%
-----------5---------------------------58.9%
-----------8---------------------------72.2%
----------12---------------------------84.3%
----------16---------------------------93.1%
----------20---------------------------100.0%

Note: Dragon Breath is also affected, as it's pretty close to being magic damage in my opinion, and I put a linear scaling formula right next to the log one (5% per level) if you want to use that one instead. I also felt like that the actual code could be put in the entityhandler, but somehow I can't get that to work.