### PR TITLE
fix of max level of fortune/looting

### DIFF
--- a/src/main/java/am2/utils/SpellUtils.java
+++ b/src/main/java/am2/utils/SpellUtils.java
@@ -88,12 +88,8 @@ public class SpellUtils {
 	
 	public static void changeEnchantmentsForShapeGroup(ItemStack stack){
 		ItemStack constructed = merge(stack);
-		int looting = 0;
-		int silkTouch = 0;
-		for (int i = 0; i < numStages(constructed); ++i){
-			looting += countModifiers(SpellModifiers.FORTUNE_LEVEL, constructed);
-			silkTouch += countModifiers(SpellModifiers.SILKTOUCH_LEVEL, constructed);
-		}
+		int looting = countModifiers(SpellModifiers.FORTUNE_LEVEL, constructed);
+		int silkTouch = countModifiers(SpellModifiers.SILKTOUCH_LEVEL, constructed);;
 
 		AMEnchantmentHelper.fortuneStack(stack, looting);
 		AMEnchantmentHelper.lootingStack(stack, looting);


### PR DESCRIPTION
fotune/looting level is count of SpellModifier Prosperity.
but (count of SpellModifier Prosperity) * (count of SpellStages) before.