### PR TITLE
Fixed strange AbilityColdBlooded crash

### DIFF
--- a/src/main/java/am2/affinity/abilities/AbilityColdBlooded.java
+++ b/src/main/java/am2/affinity/abilities/AbilityColdBlooded.java
@@ -46,8 +46,10 @@ public class AbilityColdBlooded extends AbstractAffinityAbility {
 			}else if (iceDepth >= 0.5f){
 				effect = new BuffEffectFrostSlowed(100, 1);
 			}
-			if (effect != null){
-				((EntityLivingBase)event.getSource().getEntity()).addPotionEffect(effect);
+			if (effect != null && event.getSource() != null && event.getSource().getEntity() != null){
+				try {
+					((EntityLivingBase)event.getSource().getEntity()).addPotionEffect(effect);
+				} catch (Exception ignored) {}
 			}
 		}
 	}


### PR DESCRIPTION
This kept on bringing down my Craft of the Titans game because of an NPE with the `addPotionEffect` method. After an hour of poking at it I couldn't figure out what on earth was causing it, so I just stuck it in a try/catch and called it a day. 